### PR TITLE
improve build process

### DIFF
--- a/build.rkt
+++ b/build.rkt
@@ -7,18 +7,6 @@
          "private/common.rkt"
          "private/rss.rkt"
          "generate-index.rkt")
-(require scribble/html/html
-         scribble/html/extra
-         scribble/html/xml
-         (only-in "card.rkt"
-            self-addr
-            tree
-            generate-toc
-            generate-context
-            generate-references
-            generate-backlinks
-            generate-related))
-(require (only-in scribble/text disable-prefix))
 
 (define (embed-header addr content)
   (define rkt-path (build-path "_tmp" (string-append addr ".rkt")))
@@ -35,9 +23,6 @@
   content))
 
 (struct final-card (src-path addr path target-path) #:transparent)
-
-(define (root? addr)
-  (string=? addr "index"))
 
 (define (produce-scrbl addr-list addr->path mode)
   (for/list ([addr addr-list])
@@ -241,45 +226,6 @@
 
   (produce-search)
   (produce-rss))
-
-(define (produce-indexes addr-list excludes addr-maps-to-metajson)
-  (for ([addr addr-list]
-        #:unless (set-member? excludes addr))
-    (printf "generate ~a.index.html ~n" addr)
-    (define output-dir (build-path "_build/" addr))
-    (make-directory* output-dir)
-    (define out
-      (open-output-file
-        (if (root? addr)
-          (build-path "_build" "index.html")
-          (build-path "_build" addr "index.html"))))
-    (parameterize ([self-addr addr]
-                   [generate-mode (if (root? addr) "root" "index")])
-    (if (root? addr)
-      (output-xml
-        (list
-          (doctype 'html)
-          (common-share #:title (hash-ref (hash-ref addr-maps-to-metajson addr) 'title)
-            (div 'class: "top-wrapper"
-              (tree (build-path "_tmp" (string-append addr ".embed.html"))))))
-        out)
-      (output-xml
-      (list
-      (doctype 'html)
-      (common-share #:title (hash-ref (hash-ref addr-maps-to-metajson addr) 'title)
-        (div 'class: "top-wrapper"
-          (main
-            (tree (build-path "_tmp" (string-append addr ".embed.html"))))
-          (generate-toc))
-        (footer
-          (generate-context)
-          (generate-references)
-          (generate-backlinks)
-          (generate-related))))
-      out)
-      )
-      )
-    (close-output-port out)))
 
 (define (produce-embeds addr-list addr->path excludes addr-maps-to-metajson)
   (define neighbors

--- a/generate-index.rkt
+++ b/generate-index.rkt
@@ -30,17 +30,13 @@
     (define title (hash-ref (hash-ref addr-maps-to-metajson addr) 'title))
     (parameterize ([self-addr addr]
                    [generate-root? (root? addr)])
-    (if (root? addr)
-      (output-xml
-        (list
-          (doctype 'html)
+    (output-xml
+      (list
+        (doctype 'html)
+        (if (root? addr)
           (common-share #:title title
             (div 'class: "top-wrapper"
-              (tree (build-path "_tmp" (string-append addr ".embed.html"))))))
-        out)
-      (output-xml
-        (list
-          (doctype 'html)
+              (tree (build-path "_tmp" (string-append addr ".embed.html")))))
           (common-share #:title title
             (div 'class: "top-wrapper"
               (main (tree (build-path "_tmp" (string-append addr ".embed.html"))))
@@ -50,7 +46,8 @@
               (generate-references)
               (generate-backlinks)
               (generate-related))))
-        out)))
+        )
+      out))
     (close-output-port out)))
 
 (define generate-root? (make-parameter #f))

--- a/generate-index.rkt
+++ b/generate-index.rkt
@@ -1,0 +1,36 @@
+#lang racket
+(provide generate-mode
+         common-share)
+(require scribble/html/html
+         scribble/html/extra
+         scribble/html/xml)
+
+(define generate-mode (make-parameter #f))
+#| we use strict match so other values will crash the program, are invalid input |#
+(define (generate-root?)
+  (case (generate-mode)
+    [(index) #f]
+    [(root) #t]))
+
+(define (common-share #:title this-title . content)
+  (html
+   (head
+    (meta 'http-equiv: "Content-Type" 'content: "text/html; charset=utf-8")
+    (meta 'name: "viewport" 'content: "width=device-width, initial-scale=1")
+    (title this-title)
+    (link 'rel: "stylesheet" 'href: "/katex.min.css")
+    (link 'rel: "stylesheet" 'href: "/style.css")
+
+    (script 'src: "/minisearch/index.min.js")
+    (script 'src: "/tiny.js"))
+   (body 'id: "whole"
+      (dialog 'id: "search-dialog"
+        (input 'type: "text" 'id: "search-bar"
+          'spellcheck: "false" 'autocomplete: "off"
+          'placeholder: "Start typing a note title or ID")
+        (div 'id: "search-result"))
+      (cond
+        [(generate-root?) (void)]
+        [else (a 'class: "link-home variant-strip-embed" 'href: "/" "&#171; Home")])
+      content
+      (script 'class: "variant-strip-embed" 'src: "/fullTextSearch.js"))))

--- a/generate-index.rkt
+++ b/generate-index.rkt
@@ -73,6 +73,6 @@
           'placeholder: "Start typing a note title or ID")
         (div 'id: "search-result"))
       (unless (generate-root?)
-        (a 'class: "link-home" 'href: "/" "&#171; Home"))
+        (a 'class: "link-home" 'href: "/" "« Home"))
       content
       (script 'src: "/fullTextSearch.js"))))

--- a/private/common.rkt
+++ b/private/common.rkt
@@ -2,12 +2,7 @@
 (provide
   file->json json->file
   m mm)
-(require dirname json)
-
-; (define (self-addr)
-;   (define current-scrbl-path (find-system-path 'run-file))
-;   (define self-path (path->string (path-replace-extension current-scrbl-path "")))
-;   (string-trim (basename self-path) #px"\\.index|\\.embed|\\.meta"))
+(require json)
 
 (define (file->json path)
   (define in (open-input-file path))

--- a/private/common.rkt
+++ b/private/common.rkt
@@ -1,14 +1,13 @@
 #lang racket
 (provide
-  self-addr
   file->json json->file
   m mm)
 (require dirname json)
 
-(define (self-addr)
-  (define current-scrbl-path (find-system-path 'run-file))
-  (define self-path (path->string (path-replace-extension current-scrbl-path "")))
-  (string-trim (basename self-path) #px"\\.index|\\.embed|\\.meta"))
+; (define (self-addr)
+;   (define current-scrbl-path (find-system-path 'run-file))
+;   (define self-path (path->string (path-replace-extension current-scrbl-path "")))
+;   (string-trim (basename self-path) #px"\\.index|\\.embed|\\.meta"))
 
 (define (file->json path)
   (define in (open-input-file path))


### PR DESCRIPTION
1. stop generate `*.index.scrbl` to avoid run Racket externally. Instead, do these via internal functions
2. replace old `self-addr` (which read evaluate file) with parameter

problems
- [x] back to home link missing